### PR TITLE
Remove folder path

### DIFF
--- a/data/env_development.js
+++ b/data/env_development.js
@@ -13,6 +13,6 @@ if (fs.existsSync(accountIdPath)) {
 
 module.exports = Object.assign(require('./env.js'), {
   NODE_ENV: 'development',
-  COZY_FIELDS: `{"connector": "mykonnector", "account": "${accountId}", "folder_to_save": "io.cozy.files.root-dir"}`,
+  COZY_FIELDS: `{"connector": "mykonnector", "account": "${accountId}"}`,
   DEBUG: '*'
 })

--- a/data/env_standalone.js
+++ b/data/env_standalone.js
@@ -1,5 +1,5 @@
 module.exports = Object.assign(require('./env.js'), {
   NODE_ENV: 'standalone',
-  COZY_FIELDS: `{"connector": "mykonnector", "account": "noid", "folder_to_save": "folderPath"}`,
+  COZY_FIELDS: `{"connector": "mykonnector", "account": "noid"}`,
   DEBUG: '*'
 })

--- a/manifest.konnector
+++ b/manifest.konnector
@@ -6,10 +6,6 @@
   "description": "description",
   "source": "git://github.com/cozy/cozy-konnector-maif.git",
   "fields": {
-    "save_folder": {
-      "doctype": "io.cozy.files",
-      "type": "folder"
-    },
     "account": {
       "doctype": "io.cozy.accounts",
       "account_type": "maif",


### PR DESCRIPTION
Since the maif konnector doesn't need a folder, we shouldn't have it on standalone/dev env.js files as well. 
Same thing for the manifest.